### PR TITLE
New Test for Exception in Files.FileExists

### DIFF
--- a/Test/Elements.RTL2.Tests.Shared.projitems
+++ b/Test/Elements.RTL2.Tests.Shared.projitems
@@ -9,7 +9,8 @@
     <Import_RootNamespace>Elements.RTL2.Tests.Shared</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)Stream.pas" />
+    <Compile Include="$(MSBuildThisFileDirectory)Files.pas" />
+    <Compile Include="$(MSBuildThisFileDirectory)Stream.pas" />  
     <Compile Include="$(MSBuildThisFileDirectory)Url.pas" />
     <Compile Include="$(MSBuildThisFileDirectory)Convert.pas" />
     <Compile Include="$(MSBuildThisFileDirectory)String_Paths.pas" />

--- a/Test/Files.pas
+++ b/Test/Files.pas
@@ -1,0 +1,38 @@
+﻿namespace Elements.RTL2.Tests.Shared;
+
+interface
+
+uses
+  RemObjects.Elements.RTL,
+  RemObjects.Elements.EUnit;
+
+type
+  Files = public class(Test)
+  private
+  protected
+  public
+    
+    method Fileexist;
+  end;
+
+implementation
+
+method Files.Fileexist;
+var Filename : String;
+begin
+    if Environment.OS in [OperatingSystem.Windows] then begin
+        Filename := 'C:\test\notthere.txt';
+
+        try
+            if Filename.FileExists then;
+            Assert.AreEqual(Filename.FileExists, false);
+            Assert.AreEqual(File.Exists(Filename), false);
+        except
+            on e : Exception do
+                Assert.Fail('Should not raise a Exception '+e.Message);
+        end;
+    end;
+
+end;
+
+end.


### PR DESCRIPTION
There is a Problem with File.Exists and Strings.Fileexist. They raised Exception if false, Should return false and not raise a Exception