### PR TITLE
Fix for Cooper where Doubles always parse as nil

### DIFF
--- a/Source/Convert.pas
+++ b/Source/Convert.pas
@@ -640,7 +640,8 @@ begin
 
   Symbols.DecimalSeparator := '.';
   Symbols.GroupingSeparator := ',';
-  Symbols.ExponentSeparator := 'E';
+  Symbols.ExponentSeparator := 'E+';
+  DecFormat.setDecimalFormatSymbols(Symbols);
   DecFormat.setParseIntegerOnly(false);
   var Position := new java.text.ParsePosition(0);
 


### PR DESCRIPTION
1. DecimalFormatSymbols were configured but not actually passed to DecFormat
2. Setting Symbols.ExponentSeparator as 'E' instead of 'E+' caused Position.Index to stop at the '+', meaning Position.Index < aValue.Length was true and the function always returned nil.