### PR TITLE
Fire 304: Toffee File.WriteBytes of 0 length creates empty file; Binary.ToArray of 0 length creates empty 0-element array

### DIFF
--- a/Source/RemObjects.Elements.RTL/Binary.pas
+++ b/Source/RemObjects.Elements.RTL/Binary.pas
@@ -306,8 +306,12 @@ begin
   {$IF COOPER}
   result := fData.toByteArray as not nullable;
   {$ELSEIF TOFFEE}
-  result := new Byte[mapped.length];
-  mapped.getBytes(result) length(mapped.length);
+  if mapped.length = 0 then
+    exit []
+  else begin
+    result := new Byte[mapped.length];
+    mapped.getBytes(result) length(mapped.length);
+  end;
   {$ELSEIF ECHOES OR ISLAND}
   result := mapped.ToArray as not nullable;
   {$ENDIF}

--- a/Source/RemObjects.Elements.RTL/File.pas
+++ b/Source/RemObjects.Elements.RTL/File.pas
@@ -371,7 +371,10 @@ end;
 class method File.WriteBytes(aFileName: String; Content: array of Byte);
 begin
   {$IF TOFFEE}
-  (new Binary(Content) as NSData).writeToURL(NSURL.fileURLWithPath(aFileName)) atomically(true);
+  if length(Content) > 0 then
+    (new Binary(Content) as NSData).writeToURL(NSURL.fileURLWithPath(aFileName)) atomically(true)
+  else
+    NSData.data.writeToURL(NSURL.fileURLWithPath(aFileName)) atomically(true);
   {$ELSE}
   var Handle := new FileHandle(aFileName, FileOpenMode.Create);
   try


### PR DESCRIPTION
This issue was found via behaviour in Fire: please see https://git.remobjects.com/remobjects/fire/-/issues/304